### PR TITLE
🎨 style(main-nav.tsx): Using usePathname from next/navigation to show user current page.

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -33,8 +33,9 @@ export function MainNav({ items }: MainNavProps) {
                   className={cn(
                     "flex items-center text-lg font-semibold text-muted-foreground sm:text-sm",
                     item.disabled && "cursor-not-allowed opacity-80",
-                    pathname == item.href && "text-primary"
+                    !item.disabled && pathname == item.href && "text-primary"
                   )}
+                  {...(!item.disabled && { pathname: item.href })}
                 >
                   {item.title}
                 </Link>

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -1,5 +1,7 @@
-import * as React from "react"
+"use client"
+
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 
 import { NavItem } from "@/types/nav"
 import { siteConfig } from "@/config/site"
@@ -11,6 +13,7 @@ interface MainNavProps {
 }
 
 export function MainNav({ items }: MainNavProps) {
+  const pathname = usePathname()
   return (
     <div className="flex gap-6 md:gap-10">
       <Link href="/" className="hidden items-center space-x-2 md:flex">
@@ -29,7 +32,8 @@ export function MainNav({ items }: MainNavProps) {
                   href={item.href}
                   className={cn(
                     "flex items-center text-lg font-semibold text-muted-foreground sm:text-sm",
-                    item.disabled && "cursor-not-allowed opacity-80"
+                    item.disabled && "cursor-not-allowed opacity-80",
+                    pathname == item.href && "text-primary"
                   )}
                 >
                   {item.title}


### PR DESCRIPTION
Today when I started using next-template (which is incredible and a great project!) I realized that while there is an option for disabled links in nav-items there is no option to show users the active page they are on. 

If the menu item is disabled it won't show the current directory they are active but if the menu item is not disabled it's updating CSS to text-primary to show users the active page they are on. 

