### PR TITLE
fix(next-template): remove unnecessary tailwind-indicator classnames

### DIFF
--- a/components/tailwind-indicator.tsx
+++ b/components/tailwind-indicator.tsx
@@ -4,11 +4,9 @@ export function TailwindIndicator() {
   return (
     <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">
       <div className="block sm:hidden">xs</div>
-      <div className="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">
-        sm
-      </div>
-      <div className="hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
-      <div className="hidden lg:block xl:hidden 2xl:hidden">lg</div>
+      <div className="hidden sm:block md:hidden">sm</div>
+      <div className="hidden md:block lg:hidden">md</div>
+      <div className="hidden lg:block xl:hidden">lg</div>
       <div className="hidden xl:block 2xl:hidden">xl</div>
       <div className="hidden 2xl:block">2xl</div>
     </div>


### PR DESCRIPTION
Since the breakpoint prefixes work on a `min-width` basis, it's only necessary to specify the _following_ breakpoint with `:hidden`.